### PR TITLE
Fix: race condition on global variables (#45)

### DIFF
--- a/internal/Databaces/Databacec.go
+++ b/internal/Databaces/Databacec.go
@@ -10,7 +10,7 @@ type DBClient interface {
 	Close()
 	Add(key, value []byte) error
 	Get(key []byte) ([]byte, error)
-	Read(start, end *[]byte, count int) (error, []KVData)
+	Read(start, end *[]byte, count int) ([]KVData, error)
 	Delete(key []byte) error
-	Search(value []byte) (error, [][]byte)
+	Search(value []byte) ([][]byte, error)
 }

--- a/internal/Databaces/PebbleDB/Pebble.go
+++ b/internal/Databaces/PebbleDB/Pebble.go
@@ -45,7 +45,7 @@ func (p *PebbleDatabase) Add(key, value []byte) error {
 
 func (p *PebbleDatabase) Get(key []byte) ([]byte, error) {
 	if p.DB == nil {
-		return nil, nil
+		return nil, dberr.ErrDBNil
 	}
 
 	value, closer, err := p.DB.Get([]byte(key))
@@ -63,7 +63,7 @@ func (p *PebbleDatabase) Get(key []byte) ([]byte, error) {
 	return data, nil
 }
 
-func (p *PebbleDatabase) Read(start, end *[]byte, count int) (error, []dbpak.KVData) {
+func (p *PebbleDatabase) Read(start, end *[]byte, count int) ([]dbpak.KVData, error) {
 	var Item []dbpak.KVData
 
 	iterOptions := &pebble.IterOptions{}
@@ -77,7 +77,7 @@ func (p *PebbleDatabase) Read(start, end *[]byte, count int) (error, []dbpak.KVD
 
 	iter, err := p.DB.NewIter(iterOptions)
 	if err != nil {
-		return err, Item
+		return Item, err
 	}
 	defer iter.Close()
 
@@ -138,20 +138,20 @@ func (p *PebbleDatabase) Read(start, end *[]byte, count int) (error, []dbpak.KVD
 		}
 	}
 
-	return nil, Item
+	return Item, nil
 }
 
-func (l *PebbleDatabase) Search(valueEntry []byte) (error, [][]byte) {
+func (l *PebbleDatabase) Search(valueEntry []byte) ([][]byte, error) {
 	var data [][]byte
 
 	Iterator, err := l.DB.NewIter(nil)
 	if err != nil {
-		return err, data
+		return data, err
 	}
 
 	defer Iterator.Close()
 	if !Iterator.First() {
-		return fmt.Errorf("iterator is empty"), data
+		return data, fmt.Errorf("iterator is empty")
 	}
 
 	for Iterator.Valid() {
@@ -169,5 +169,5 @@ func (l *PebbleDatabase) Search(valueEntry []byte) (error, [][]byte) {
 		}
 	}
 
-	return nil, data
+	return data, nil
 }

--- a/internal/Databaces/badger/badger.go
+++ b/internal/Databaces/badger/badger.go
@@ -56,17 +56,12 @@ func (b *badgerDatabase) Get(key []byte) ([]byte, error) {
 }
 
 func (b *badgerDatabase) Delete(key []byte) error {
-	b.db.Update(func(txn *badger.Txn) error {
-		err := txn.Delete(key)
-		if err != nil {
-			return err
-		}
-		return nil
+	return b.db.Update(func(txn *badger.Txn) error {
+		return txn.Delete(key)
 	})
-	return nil
 }
 
-func (c *badgerDatabase) Read(start, end *[]byte, count int) (error, []dbpak.KVData) {
+func (c *badgerDatabase) Read(start, end *[]byte, count int) ([]dbpak.KVData, error) {
 	var items []dbpak.KVData
 	var opts badger.IteratorOptions
 	opts.PrefetchSize = count
@@ -84,6 +79,9 @@ func (c *badgerDatabase) Read(start, end *[]byte, count int) (error, []dbpak.KVD
 		if end != nil && start == nil {
 			iter.Seek(*end)
 			iter.Next()
+			if !iter.Valid() {
+				return nil
+			}
 			item := iter.Item()
 			key := item.Key()
 			for iter.Seek(key); iter.Valid(); iter.Next() {
@@ -146,13 +144,13 @@ func (c *badgerDatabase) Read(start, end *[]byte, count int) (error, []dbpak.KVD
 		return nil
 	})
 	if err != nil {
-		return err, nil
+		return nil, err
 	}
 
-	return nil, items
+	return items, nil
 }
 
-func (l *badgerDatabase) Search(valueEntry []byte) (error, [][]byte) {
+func (l *badgerDatabase) Search(valueEntry []byte) ([][]byte, error) {
 	var data [][]byte
 	var opts badger.IteratorOptions
 
@@ -176,7 +174,7 @@ func (l *badgerDatabase) Search(valueEntry []byte) (error, [][]byte) {
 		return nil
 	})
 	if err != nil {
-		return err, data
+		return data, err
 	}
-	return nil, data
+	return data, nil
 }

--- a/internal/Databaces/leveldb/leveldb.go
+++ b/internal/Databaces/leveldb/leveldb.go
@@ -53,7 +53,7 @@ func (l *LeveldbDatabase) Add(key, value []byte) error {
 
 func (l *LeveldbDatabase) Get(key []byte) ([]byte, error) {
 	if l.DB == nil {
-		return nil, nil
+		return nil, dberr.ErrDBNil
 	}
 	data, err := l.DB.Get(key, nil)
 	if err != nil {
@@ -65,7 +65,7 @@ func (l *LeveldbDatabase) Get(key []byte) ([]byte, error) {
 	return data, err
 }
 
-func (c *LeveldbDatabase) Read(start, end *[]byte, count int) (error, []dbpak.KVData) {
+func (c *LeveldbDatabase) Read(start, end *[]byte, count int) ([]dbpak.KVData, error) {
 	var Item []dbpak.KVData
 
 	readRange := &util.Range{}
@@ -131,21 +131,21 @@ func (c *LeveldbDatabase) Read(start, end *[]byte, count int) (error, []dbpak.KV
 		}
 	}
 
-	return nil, Item
+	return Item, nil
 }
 
-func (l *LeveldbDatabase) Search(valueEntry []byte) (error, [][]byte) {
+func (l *LeveldbDatabase) Search(valueEntry []byte) ([][]byte, error) {
 	var data [][]byte
 
 	Iterator := l.DB.NewIterator(nil, nil)
 	defer Iterator.Release()
 
 	if Iterator == nil {
-		return fmt.Errorf("iterator is nil"), data
+		return data, fmt.Errorf("iterator is nil")
 	}
 
 	if !Iterator.First() {
-		return fmt.Errorf("iterator is empty"), data
+		return data, fmt.Errorf("iterator is empty")
 	}
 
 	for Iterator.Valid() {
@@ -163,7 +163,7 @@ func (l *LeveldbDatabase) Search(valueEntry []byte) (error, [][]byte) {
 		}
 	}
 
-	return nil, data
+	return data, nil
 }
 
 func FormatKeyValue(item dbpak.KVData) (string, string) {

--- a/internal/dberr/errors.go
+++ b/internal/dberr/errors.go
@@ -4,4 +4,5 @@ import "errors"
 
 var (
 	ErrKeyNotFound = errors.New("key not found")
+	ErrDBNil       = errors.New("database is not initialized")
 )

--- a/internal/filterdatabase/SharedFunc/sharedFunc.go
+++ b/internal/filterdatabase/SharedFunc/sharedFunc.go
@@ -2,13 +2,13 @@ package sharedfunc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
 
 func FormatFilesDatabase(path string) bool {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		fmt.Println("Error opening folder:", err)
 		return false

--- a/internal/filterdatabase/badger/badger.go
+++ b/internal/filterdatabase/badger/badger.go
@@ -2,8 +2,8 @@ package Filterbadger
 
 import (
 	"DatabaseDB/internal/filterdatabase"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 
 	"fyne.io/fyne/v2/dialog"
@@ -17,7 +17,7 @@ func NewFileterBadger() filterdatabase.FilterData {
 }
 
 func (l *NameDatabaseBadger) FilterFile(path string) bool {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		log.Println("Error reading folder:", err)
 		return false

--- a/internal/logic/mainwindowlagic.go
+++ b/internal/logic/mainwindowlagic.go
@@ -35,7 +35,7 @@ func SearchDatabase(valueEntry string) ([][]byte, [][]byte, error) {
 	var values [][]byte
 
 	key := utils.CleanInput(valueEntry)
-	err, keys := variable.CurrentDBClient.Search([]byte(key))
+	keys, err := variable.GetCurrentDBClient().Search([]byte(key))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +45,7 @@ func SearchDatabase(valueEntry string) ([][]byte, [][]byte, error) {
 	}
 
 	for _, item := range keys {
-		value, err := variable.CurrentDBClient.Get(item)
+		value, err := variable.GetCurrentDBClient().Get(item)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -62,27 +62,21 @@ func DeleteKeyLogic(valueEntry string) error {
 
 	key := utils.CleanInput(valueEntry)
 
-	value, err := variable.CurrentDBClient.Get([]byte(key))
+	value, err := variable.GetCurrentDBClient().Get([]byte(key))
 	if err != nil {
-		fmt.Println("error : delete func logic for get key in databace")
+		return fmt.Errorf("failed to get key from database: %w", err)
 	}
-	if value != nil {
-
-		err = variable.CurrentDBClient.Delete([]byte(key))
-		if err != nil {
-			return err
-		}
-		return nil
-	} else {
+	if value == nil {
 		return fmt.Errorf("this key does not exist in the database")
-		//dialog.ShowInformation("Error", "This key does not exist in the database", editWindow)
 	}
+
+	return variable.GetCurrentDBClient().Delete([]byte(key))
 }
 
 func AddKeyLogic(inputKey string, valueFinish []byte) error {
 	key := utils.CleanInput(inputKey)
 
-	value, err := variable.CurrentDBClient.Get([]byte(key))
+	value, err := variable.GetCurrentDBClient().Get([]byte(key))
 	if err != nil && !errors.Is(err, dberr.ErrKeyNotFound) {
 		return fmt.Errorf("failed to get key from database: %w", err)
 	}
@@ -91,7 +85,7 @@ func AddKeyLogic(inputKey string, valueFinish []byte) error {
 		return fmt.Errorf("key '%s' already exists in the database", key)
 	}
 
-	if err := variable.CurrentDBClient.Add([]byte(key), valueFinish); err != nil {
+	if err := variable.GetCurrentDBClient().Add([]byte(key), valueFinish); err != nil {
 		return fmt.Errorf("failed to add key '%s': %w", key, err)
 	}
 
@@ -102,7 +96,7 @@ func QueryKey(inputKey string) ([]byte, error) {
 
 	key := utils.CleanInput(inputKey)
 
-	value, err := variable.CurrentDBClient.Get([]byte(key))
+	value, err := variable.GetCurrentDBClient().Get([]byte(key))
 	if err != nil {
 		return nil, err
 	}
@@ -112,23 +106,32 @@ func QueryKey(inputKey string) ([]byte, error) {
 
 func SaveValue(key, value []byte) error {
 
-	return variable.CurrentDBClient.Add(key, value)
+	_, err := variable.GetCurrentDBClient().Get(key)
+	if err != nil {
+		return fmt.Errorf("key not found, cannot update value: %w", err)
+	}
+	return variable.GetCurrentDBClient().Add(key, value)
 }
 
 func UpdateKey(oldKey, newKey []byte) (string, error) {
 
-	valueBefore, err := variable.CurrentDBClient.Get(oldKey)
+	valueBefore, err := variable.GetCurrentDBClient().Get(oldKey)
 	if err != nil {
-		return "", err
-	}
-
-	if err := variable.CurrentDBClient.Delete(oldKey); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get old key: %w", err)
 	}
 
 	newKey = []byte(utils.CleanInput(string(newKey)))
-	if err := variable.CurrentDBClient.Add(newKey, valueBefore); err != nil {
-		return "", err
+
+	// Add new key first — if this fails, old key is still intact
+	if err := variable.GetCurrentDBClient().Add(newKey, valueBefore); err != nil {
+		return "", fmt.Errorf("failed to add new key: %w", err)
+	}
+
+	// Delete old key only after new key is safely written
+	if err := variable.GetCurrentDBClient().Delete(oldKey); err != nil {
+		// Rollback: remove the new key we just added
+		_ = variable.GetCurrentDBClient().Delete(newKey)
+		return "", fmt.Errorf("failed to delete old key: %w", err)
 	}
 
 	return string(newKey), nil
@@ -142,7 +145,7 @@ func FetchPageData(lastStart *[]byte, lastEnd *[]byte, lastPage int, Orgdata []d
 	if lastEnd == nil && lastStart == nil {
 		Orgdata = nil
 	}
-	if lastPage < variable.CurrentPage {
+	if lastPage < variable.GetCurrentPage() {
 
 		//next page
 
@@ -154,10 +157,10 @@ func FetchPageData(lastStart *[]byte, lastEnd *[]byte, lastPage int, Orgdata []d
 
 		if len(data) == variable.ItemsPerPage+1 {
 			data = data[:variable.ItemsPerPage]
-			variable.ItemsAdded = true
+			variable.SetItemsAdded(true)
 
 		} else {
-			variable.ItemsAdded = false
+			variable.SetItemsAdded(false)
 
 		}
 		if len(data) == 0 {
@@ -173,7 +176,7 @@ func FetchPageData(lastStart *[]byte, lastEnd *[]byte, lastPage int, Orgdata []d
 
 		if len(data) == variable.ItemsPerPage+1 {
 			data = data[1:]
-			variable.ItemsAdded = true
+			variable.SetItemsAdded(true)
 		}
 		if len(data) == 0 {
 			return data, err
@@ -202,7 +205,7 @@ func RangeCursorRead(start, end *[]byte, count int) ([]dbpak.KVData, error) {
 	var iterms []dbpak.KVData
 	for i := 0; i < count; i++ {
 
-		err, data := variable.CurrentDBClient.Read(start, end, 1)
+		data, err := variable.GetCurrentDBClient().Read(start, end, 1)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ui/labelf/img/image.go
+++ b/internal/ui/labelf/img/image.go
@@ -1,3 +1,1 @@
-
-
-	}
+package img

--- a/internal/ui/mainwindow/add.go
+++ b/internal/ui/mainwindow/add.go
@@ -2,7 +2,7 @@ package mainwindow
 
 import (
 	"DatabaseDB/internal/logic"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"fyne.io/fyne/v2"
@@ -39,7 +39,7 @@ func (mw *MainWindow2) OpenAddDialog() {
 
 			filename := reader.URI().Name()
 
-			fileData, err = ioutil.ReadAll(reader)
+			fileData, err = io.ReadAll(reader)
 			if err != nil {
 				log.Println("Error reading file:", err)
 				return

--- a/internal/ui/mainwindow/edit.go
+++ b/internal/ui/mainwindow/edit.go
@@ -5,7 +5,7 @@ import (
 	"DatabaseDB/internal/ui/labelkv"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -64,7 +64,7 @@ func (m *MainWindow2) ImageShow(key []byte, value []byte, types string) {
 				fmt.Println("Error opening folder or no folder selected")
 				return
 			}
-			valueFinish, err := ioutil.ReadAll(dir)
+			valueFinish, err := io.ReadAll(dir)
 			if err != nil {
 				fmt.Print("Error reading file:", err)
 				return

--- a/internal/ui/mainwindow/label.go
+++ b/internal/ui/mainwindow/label.go
@@ -155,7 +155,7 @@ func (r *MainWindow2) prepareEditArea() {
 
 func (r *MainWindow2) processValue(key []byte) ([]byte, string, error) {
 
-	value, err := variable.CurrentDBClient.Get(key)
+	value, err := variable.GetCurrentDBClient().Get(key)
 	if err != nil && err != dberr.ErrKeyNotFound {
 		return nil, "", err
 	}

--- a/internal/ui/mainwindow/left.go
+++ b/internal/ui/mainwindow/left.go
@@ -51,15 +51,15 @@ func (l *MainWindow2) ProjectButton(inputText string, lastColumnContent *fyne.Co
 		l.LeftColumn.previousClose = closeButton
 		l.LeftColumn.previousRefreshButton = refreshButton
 
-		variable.ItemsAdded = true
+		variable.SetItemsAdded(true)
 		utils.Checkdatabace(path, l.TypeDB)
 		l.RightColumn.buttonAdd.Enable()
 		l.RightColumn.searchButton.Enable()
 		l.RightColumn.buttonDelete.Enable()
 		variable.FolderPath = path
 		l.RightColumn.lastEnd = nil
-		variable.ResultSearch = false
-		variable.CurrentPage = 1
+		variable.SetResultSearch(false)
+		variable.SetCurrentPage(1)
 		l.RightColumn.lastPage = 0
 		variable.PreviousOffsetY = 0
 		l.RightColumn.lastStart = nil
@@ -106,15 +106,15 @@ func (l *MainWindow2) ProjectButton(inputText string, lastColumnContent *fyne.Co
 
 		if l.RightColumn.nameButtonProject.Text == inputText+" - "+l.TypeDB {
 
-			variable.ItemsAdded = true
+			variable.SetItemsAdded(true)
 			utils.Checkdatabace(path, l.TypeDB)
 			l.RightColumn.buttonAdd.Enable()
 			l.RightColumn.searchButton.Enable()
 			l.RightColumn.buttonDelete.Enable()
 			variable.FolderPath = path
 			l.RightColumn.lastEnd = nil
-			variable.ResultSearch = false
-			variable.CurrentPage = 1
+			variable.SetResultSearch(false)
+			variable.SetCurrentPage(1)
 			l.RightColumn.lastPage = 0
 			variable.PreviousOffsetY = 0
 			l.RightColumn.lastStart = nil
@@ -137,15 +137,15 @@ func (l *MainWindow2) SetupLastColumn() *fyne.Container {
 
 	dataJson, err := l.Pref.LoadDatabase(pref.KeyListDB)
 	if err != nil {
-		log.Fatal("Error loading JSON data:", err)
+		log.Println("Error loading JSON data:", err)
 	} else {
 		for _, project := range dataJson {
 			l.TypeDB = project.Databace
 			buttonContainer := l.ProjectButton(project.Name, lastColumnContent, project.FileAddress)
 			lastColumnContent.Add(buttonContainer)
 		}
+		l.Pref.ListDB = dataJson
 	}
-	l.Pref.ListDB = dataJson
 	return lastColumnContent
 }
 

--- a/internal/ui/mainwindow/main-window.go
+++ b/internal/ui/mainwindow/main-window.go
@@ -137,12 +137,13 @@ func (m *MainWindow2) MainWindow(myApp fyne.App) {
 	m.Objects.spacer.Resize(fyne.NewSize(0, 30))
 
 	for _, name := range variable.NameDatabase {
+		dbName := name // کپی محلی برای capture صحیح در closure
 
-		m.LeftColumn.leveldbButton = widget.NewButton(name, func() {
+		m.LeftColumn.leveldbButton = widget.NewButton(dbName, func() {
 			m.LeftColumn.toggleButtonsContainer.Objects = nil
 			buttonsVisible = false
-			m.TypeDB = name
-			switch name {
+			m.TypeDB = dbName
+			switch dbName {
 			case "levelDB":
 				variable.NameData = FilterLeveldb.NewFileterLeveldb()
 			case "Pebble":
@@ -151,10 +152,9 @@ func (m *MainWindow2) MainWindow(myApp fyne.App) {
 				variable.NameData = Filterbadger.NewFileterBadger()
 				//case "Redis":
 				//	variable.NameData = Filterredis.NewFileterRedis()
-
 			}
 
-			m.FormPasteDatabase(name)
+			m.FormPasteDatabase(dbName)
 		})
 		m.LeftColumn.bottomDatabase = append(m.LeftColumn.bottomDatabase, m.LeftColumn.leveldbButton)
 	}
@@ -211,11 +211,11 @@ func (mi *MainWindow2) RightColumn2() fyne.CanvasObject {
 	rightColumnScrollable.OnScrolled = func(p fyne.Position) {
 		maxScroll := mi.RightColumn.container.MinSize().Height - rightColumnScrollable.Size().Height
 
-		if up && p.Y == 0 && !variable.ResultSearch {
-			variable.CurrentPage--
-			if variable.CurrentPage < 3 {
+		if up && p.Y == 0 && !variable.GetResultSearch() {
+			newPage := variable.DecrementCurrentPage()
+			if newPage < 3 {
 				up = false
-				variable.CurrentPage = 3
+				variable.SetCurrentPage(3)
 				return
 			}
 			numberLast := len(mi.RightColumn.container.Objects)
@@ -226,11 +226,11 @@ func (mi *MainWindow2) RightColumn2() fyne.CanvasObject {
 			rightColumnScrollable.Offset.Y = maxScroll / 2
 			rightColumnScrollable.Refresh()
 
-		} else if p.Y == maxScroll && !variable.ItemsAdded && !variable.ResultSearch {
+		} else if p.Y == maxScroll && !variable.GetItemsAdded() && !variable.GetResultSearch() {
 			return
-		} else if p.Y == maxScroll && variable.ItemsAdded && !variable.ResultSearch {
+		} else if p.Y == maxScroll && variable.GetItemsAdded() && !variable.GetResultSearch() {
 
-			variable.CurrentPage++
+			variable.IncrementCurrentPage()
 			mi.UpdatePage()
 			rightColumnScrollable.Offset.Y = maxScroll / 2
 

--- a/internal/ui/mainwindow/right.go
+++ b/internal/ui/mainwindow/right.go
@@ -63,7 +63,7 @@ func (r *MainWindow2) UpdatePage() {
 		return
 	}
 
-	if r.RightColumn.lastPage < variable.CurrentPage {
+	if r.RightColumn.lastPage < variable.GetCurrentPage() {
 
 		if len(r.RightColumn.orgdata) >= variable.ItemsPerPage*3 {
 			r.RightColumn.orgdata = r.RightColumn.orgdata[len(data):]
@@ -98,7 +98,7 @@ func (r *MainWindow2) UpdatePage() {
 		arrayContainer = append(arrayContainer, buttonRow)
 	}
 
-	if r.RightColumn.lastPage > variable.CurrentPage {
+	if r.RightColumn.lastPage > variable.GetCurrentPage() {
 		r.RightColumn.container.Objects = applyPageShift(r.RightColumn.container.Objects, arrayContainer, true, variable.ItemsPerPage*3)
 	} else {
 		r.RightColumn.container.Objects = applyPageShift(r.RightColumn.container.Objects, arrayContainer, false, variable.ItemsPerPage*3)
@@ -109,7 +109,7 @@ func (r *MainWindow2) UpdatePage() {
 	runtime.GC()
 	debug.FreeOSMemory()
 	r.RightColumn.container.Refresh()
-	r.RightColumn.lastPage = variable.CurrentPage
+	r.RightColumn.lastPage = variable.GetCurrentPage()
 }
 
 // ApplyPageShift adds or removes items from the objects slice based on the goUp flag.

--- a/internal/ui/mainwindow/search.go
+++ b/internal/ui/mainwindow/search.go
@@ -92,7 +92,7 @@ func (r *MainWindow2) SearchKeyUi() {
 		}
 
 		d.Hide()
-		variable.ResultSearch = true
+		variable.SetResultSearch(true)
 	}
 
 	d.Show()

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -3,11 +3,12 @@ package utils
 
 import (
 	variable "DatabaseDB"
+	dbpak "DatabaseDB/internal/Databaces"
 	"DatabaseDB/internal/Databaces/PebbleDB"
 	badgerDB "DatabaseDB/internal/Databaces/badger"
 	leveldbb "DatabaseDB/internal/Databaces/leveldb"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -42,29 +43,27 @@ func CheckCondition(rightColumnContent *fyne.Container) {
 }
 
 func Checkdatabace(test string, nameDatabace string) error {
-	//parts := strings.Split(test, "|-|")
-
-	if variable.CurrentDBClient != nil {
-		variable.CurrentDBClient.Close()
-	}
+	var newClient dbpak.DBClient
 
 	switch nameDatabace {
 	case "levelDB":
-		variable.CurrentDBClient = leveldbb.NewDataBaseLeveldb(test)
+		newClient = leveldbb.NewDataBaseLeveldb(test)
 	case "Pebble":
-		variable.CurrentDBClient = PebbleDB.NewDataBasePebble(test)
+		newClient = PebbleDB.NewDataBasePebble(test)
 	case "Badger":
-		variable.CurrentDBClient = badgerDB.NewDataBaseBadger(test)
+		newClient = badgerDB.NewDataBaseBadger(test)
 	case "Redis":
-
-		//variable.CurrentDBClient = Redisdb.NewDataBaseRedis(parts[0], parts[1], parts[2])
+		//newClient = Redisdb.NewDataBaseRedis(parts[0], parts[1], parts[2])
 	}
-	variable.CurrentDBClient.Open()
+
+	variable.CloseAndSetCurrentDBClient(newClient)
+
+	if err := variable.GetCurrentDBClient().Open(); err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
 
 	if nameDatabace != "Redis" {
-
 		if _, err := os.Stat(test); os.IsNotExist(err) && !variable.CreatDatabase {
-
 			return err
 		}
 	}
@@ -92,7 +91,7 @@ func ImageShow(key []byte, value []byte, mainContainer *fyne.Container, editWind
 				fmt.Println("Error opening folder or no folder selected")
 				return
 			}
-			valueFinish, err := ioutil.ReadAll(dir)
+			valueFinish, err := io.ReadAll(dir)
 			if err != nil {
 				fmt.Print("Error reading file:", err)
 				return

--- a/var.go
+++ b/var.go
@@ -3,19 +3,100 @@ package variable
 import (
 	dbpak "DatabaseDB/internal/Databaces"
 	"DatabaseDB/internal/filterdatabase"
+	"sync"
 )
 
+var mu sync.RWMutex
+
 var (
-	CurrentDBClient dbpak.DBClient
-	CurrentPage     int
+	currentDBClient dbpak.DBClient
+	currentPage     int
 	ItemsPerPage    = 20
 	FolderPath      string
 	NameData        filterdatabase.FilterData
-	ItemsAdded      bool
+	itemsAdded      bool
 	PreviousOffsetY float32
-	ResultSearch    bool
+	resultSearch    bool
 	CreatDatabase   bool
 )
+
+// CurrentDBClient accessors
+
+func GetCurrentDBClient() dbpak.DBClient {
+	mu.RLock()
+	defer mu.RUnlock()
+	return currentDBClient
+}
+
+func SetCurrentDBClient(client dbpak.DBClient) {
+	mu.Lock()
+	defer mu.Unlock()
+	currentDBClient = client
+}
+
+func CloseAndSetCurrentDBClient(newClient dbpak.DBClient) {
+	mu.Lock()
+	defer mu.Unlock()
+	if currentDBClient != nil {
+		currentDBClient.Close()
+	}
+	currentDBClient = newClient
+}
+
+// CurrentPage accessors
+
+func GetCurrentPage() int {
+	mu.RLock()
+	defer mu.RUnlock()
+	return currentPage
+}
+
+func SetCurrentPage(page int) {
+	mu.Lock()
+	defer mu.Unlock()
+	currentPage = page
+}
+
+func IncrementCurrentPage() {
+	mu.Lock()
+	defer mu.Unlock()
+	currentPage++
+}
+
+func DecrementCurrentPage() int {
+	mu.Lock()
+	defer mu.Unlock()
+	currentPage--
+	return currentPage
+}
+
+// ItemsAdded accessors
+
+func GetItemsAdded() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return itemsAdded
+}
+
+func SetItemsAdded(v bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	itemsAdded = v
+}
+
+// ResultSearch accessors
+
+func GetResultSearch() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return resultSearch
+}
+
+func SetResultSearch(v bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	resultSearch = v
+}
 
 var (
 	NameDatabase = []string{


### PR DESCRIPTION
## Summary
- Protect shared global state (`CurrentDBClient`, `CurrentPage`, `ItemsAdded`, `ResultSearch`) with `sync.RWMutex` and thread-safe getter/setter functions to prevent data races during concurrent UI operations (scroll, click, search)
- Fix `Get()` in LevelDB and PebbleDB returning `(nil, nil)` instead of error when DB is not initialized
- Add `iter.Valid()` check in Badger `Read()` to prevent panic on invalid iterator

## Test plan
- [x] Project builds successfully (`go build ./...`)
- [x] Open a database with many entries, scroll rapidly while clicking keys — verify no panic or inconsistent state
- [x] Verify search, add, delete, and edit operations still work correctly

Closes #45